### PR TITLE
friendly for pinning on mobile

### DIFF
--- a/app/components/PocketNode.js
+++ b/app/components/PocketNode.js
@@ -42,15 +42,16 @@ module.exports = React.createClass({
       // Return defaultValue, and set focus
       this.setState({ inputValue: null }, () => {
         setTimeout(() => {
-          this.refs.textInput.focus();          
+          this.refs.textInput.focus();
         }, 100);
       });
-      
+
       // Keep scrolling to the bottom
-      document.body.scrollTop = document.body.scrollHeight;
+      var element = document.getElementById("container");
+      element.scrollTop = element.offsetHeight;
     });
   },
-  
+
   render: function () {
     return (
       <div

--- a/index.html
+++ b/index.html
@@ -2,7 +2,9 @@
 <html>
 <head>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1.0,minimal-ui,shrink-to-fit=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <title>PocketNode</title>
   <style type="text/css">
     * {
@@ -12,9 +14,19 @@
       font-size: 12px;
     }
 
+    html {
+      height:100%;
+      overflow: hidden;
+    }
     body {
       margin: 0;
       cursor: default;
+      height: 100%;
+      overflow: hidden;
+    }
+    #container {
+      overflow-y:auto;
+      height: 100%;
     }
   </style>
 </head>


### PR DESCRIPTION
I made the viewport disappear when pinned to the home screen on iOS using the minimal ui tag. Also, set the container to the be the scrollable element, and not the body which behaves better when pinned and trying to anchor the container to the bottom after input. At some point, someone could add favicons so the home screen icon is nice.
